### PR TITLE
update flatpak filesystem permissions: from home -> xdg-config

### DIFF
--- a/flatpak/com.mikeasoft.pied.yaml
+++ b/flatpak/com.mikeasoft.pied.yaml
@@ -11,7 +11,7 @@ finish-args:
   - --device=dri
   - --socket=pulseaudio
   - --share=network
-  - --filesystem=home
+  - --filesystem=xdg-config
   - --talk-name=org.freedesktop.Flatpak
 modules:
   - name: Pied


### PR DESCRIPTION
tested on a clean install - Pied looks in .config/speech-dispatcher, creates a backup if it exists, and overwrites it. This makes it clear what permissions pied needs as opposed to the broad filesystem=home.